### PR TITLE
fix: actually use "body" property

### DIFF
--- a/src/utils/streams.ts
+++ b/src/utils/streams.ts
@@ -19,7 +19,7 @@ export const getStream = async (input: string, options: UseChatStreamOptions, me
   const response = await fetch(options.url + params, { 
     method: options.method,
     headers: options.headers,
-    body: JSON.stringify(options.body)
+    body: JSON.stringify(options.body, (_k, v) => v === null ? undefined : v)
   });
 
   if (!response.ok) throw new Error(response.statusText);

--- a/src/utils/streams.ts
+++ b/src/utils/streams.ts
@@ -16,7 +16,11 @@ export const getStream = async (input: string, options: UseChatStreamOptions, me
 
   const params = '?' + new URLSearchParams(options.query).toString();
 
-  const response = await fetch(options.url + params, { method: options.method, headers: options.headers });
+  const response = await fetch(options.url + params, { 
+    method: options.method,
+    headers: options.headers,
+    body: JSON.stringify(options.body)
+  });
 
   if (!response.ok) throw new Error(response.statusText);
 


### PR DESCRIPTION
I've noticed, that when you use `method.type: 'body'` nothing really happens and we're not sending payload. This PR fixes it.