### PR TITLE
fix crash when not using query

### DIFF
--- a/src/utils/streams.ts
+++ b/src/utils/streams.ts
@@ -4,8 +4,7 @@ import type {
 } from '../hooks/useChatStream';
 
 const mergeInputInOptions = (input: string, options: UseChatStreamOptions, method: UseChatStreamInputMethod) => {
-  options.query = options.query ?? {};
-  (options[method.type] as Record<string, unknown>)[method.key] = input;
+  (options[method.type] ?? {})[method.key] = input;
 
   return options;
 };


### PR DESCRIPTION
This PR fixes the `Something went wrong fetching AI response.` error before any request happens.

This appears for example with the example code in the readme.